### PR TITLE
fix: add gap between course management cards (#57)

### DIFF
--- a/packages/site/app/instructors-view.tsx
+++ b/packages/site/app/instructors-view.tsx
@@ -111,7 +111,7 @@ export default function InstructorsView() {
         <p className="pb-4 font-medium text-sm leading-none">
           Course Management
         </p>
-        <div className="grid grid-cols-3">
+        <div className="grid grid-cols-3 gap-4">
           {iCourses.map((course) => {
             return (
               <Link


### PR DESCRIPTION
## Fix: Add gap between course management cards

**Fixes #57**

### Problem
The course management cards on the instructor's view were displayed without any spacing between them, making the UI look cramped and harder to read.

### Solution
Added `gap-4` Tailwind CSS utility class to the grid container that displays the course management cards. This adds a 1rem (16px) gap between cards both horizontally and vertically.

### Changes Made
- Modified `crs/packages/site/app/instructors-view.tsx`
- Changed `className="grid grid-cols-3"` to `className="grid grid-cols-3 gap-4"`

### Technical Details
The fix applies to the grid container on line 114 of the instructors view component. The `gap-4` utility class is a standard Tailwind CSS spacing utility that provides consistent spacing across the application.

### Testing
- ✅ No TypeScript errors
- ✅ Maintains existing grid layout functionality
- ✅ Consistent with Tailwind CSS best practices

### Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] UI/UX improvement