### PR TITLE
fix(admin): difference assessment due time w/ default to chosen month and checking logic

### DIFF
--- a/packages/site/components/instructor/admin/assignment/assignment-form.tsx
+++ b/packages/site/components/instructor/admin/assignment/assignment-form.tsx
@@ -126,6 +126,7 @@ export function AssignmentForm({
                         field.onChange(updated.toISO());
                       }
                     }}
+                    captionLayout="dropdown"
                     className="rounded-lg border shadow-sm"
                   />
                 </PopoverContent>
@@ -205,6 +206,7 @@ export function AssignmentForm({
                         field.onChange(extensionDateTime.diff(due).toISO());
                       }
                     }}
+                    captionLayout="dropdown"
                     className="rounded-lg border shadow-sm"
                   />
                 )}


### PR DESCRIPTION
Resolve #99

Changes: 
- User now need to pick the Due date first before picking values for other elements
- The Dates are now correctly mapped to the right Month (and day), for those existing objects

Preview:
<img width="1624" height="1002" alt="image" src="https://github.com/user-attachments/assets/d9e8f89e-e78b-4d11-ac4c-6d5e85c5bef3" />
<img width="1624" height="1002" alt="image" src="https://github.com/user-attachments/assets/e71a5d68-ff70-4084-acea-22e47391413d" />

